### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/GeoIP/City.pm
+++ b/lib/GeoIP/City.pm
@@ -1,6 +1,6 @@
 use NativeCall;
 
-class GeoIP::City is repr('CPointer');
+unit class GeoIP::City is repr('CPointer');
 
 class GeoIPRecord is repr('CStruct') {
     has Str $.country_code;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.