### PR TITLE
Fix $*VM config information lookup

### DIFF
--- a/lib/GeoIP/City.pm
+++ b/lib/GeoIP/City.pm
@@ -25,7 +25,7 @@ class GeoIPRecord is repr('CStruct') {
 # point NativeCall to correct library
 # (may become obsolete in the future)
 sub LIB  {
-    given $*VM{'config'}{'load_ext'} {
+    given $*VM.config{'load_ext'} {
         when '.so'      { return 'libGeoIP.so.1' }   # Linux
         when '.bundle'  { return 'libGeoIP.dylib' }  # Mac OS
         default         { return 'libGeoIP' }


### PR DESCRIPTION
To get a VM's config, one has to use the `.config` method call to return
what used to be stored in a hash element.  This change updates the
`load_ext` check to the new usage.