### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/city.t
+++ b/t/city.t
@@ -7,7 +7,7 @@ plan( 5 );
 
 my $geo;
 
-lives_ok { $geo = GeoIP::City.new }, 'initialize free database';
+lives-ok { $geo = GeoIP::City.new }, 'initialize free database';
 
 ok $geo.info ~~ /GEO .* LITE .* \d ** 8/, 'info';
 


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants. The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.