### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,6 +8,6 @@
         "GeoIP" : "lib/GeoIP.pm",
         "GeoIP::City" : "lib/GeoIP/City.pm"
     },
-    "license" : "http://www.perlfoundation.org/artistic_license_2_0",
+    "license" : "Artistic-2.0",
     "source-url" : "git://github.com/bbkr/GeoIPerl6.git"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license